### PR TITLE
Set type=click.UUID for UUID ids

### DIFF
--- a/tre/commands/shared_services/operation.py
+++ b/tre/commands/shared_services/operation.py
@@ -8,7 +8,7 @@ from .contexts import pass_shared_service_operation_context, SharedServiceOperat
 
 
 @click.group(name="operation", invoke_without_command=True, help="Perform actions on an operation")
-@click.argument('operation_id', required=True)
+@click.argument('operation_id', required=True, type=click.UUID)
 @click.pass_context
 def shared_service_operation(ctx: click.Context, operation_id) -> None:
     ctx.obj = SharedServiceOperationContext.add_operation_id_to_context_obj(ctx, operation_id)

--- a/tre/commands/shared_services/shared_service.py
+++ b/tre/commands/shared_services/shared_service.py
@@ -11,7 +11,7 @@ from .operations import shared_service_operations
 
 
 @click.group(invoke_without_command=True, help="Perform actions on an individual shared_service")
-@click.argument('shared_service_id', envvar='TRECLI_WORKSPACE_ID', required=True)
+@click.argument('shared_service_id', required=True, type=click.UUID)
 @click.pass_context
 def shared_service(ctx: click.Context, shared_service_id: str) -> None:
     ctx.obj = SharedServiceContext(shared_service_id)

--- a/tre/commands/workspaces/airlock/request.py
+++ b/tre/commands/workspaces/airlock/request.py
@@ -21,7 +21,7 @@ def airlock_id_completion(ctx: click.Context, param, incomplete):
 
 
 @click.group(invoke_without_command=True, help="Perform actions on an airlock request")
-@click.argument('airlock_id', required=True, shell_complete=airlock_id_completion)
+@click.argument('airlock_id', required=True, type=click.UUID, shell_complete=airlock_id_completion)
 @click.pass_context
 def airlock(ctx: click.Context, airlock_id: str) -> None:
     ctx.obj = WorkspaceAirlockContext.add_airlock_id_to_context_obj(ctx, airlock_id)

--- a/tre/commands/workspaces/operation.py
+++ b/tre/commands/workspaces/operation.py
@@ -7,7 +7,7 @@ from .contexts import pass_workspace_operation_context, WorkspaceOperationContex
 
 
 @click.group(name="operation", invoke_without_command=True, help="Perform actions on an operation")
-@click.argument('operation_id', required=True)
+@click.argument('operation_id', required=True, type=click.UUID)
 @click.pass_context
 def workspace_operation(ctx: click.Context, operation_id) -> None:
     ctx.obj = WorkspaceOperationContext.add_operation_id_to_context_obj(ctx, operation_id)

--- a/tre/commands/workspaces/workspace.py
+++ b/tre/commands/workspaces/workspace.py
@@ -24,7 +24,7 @@ def workspace_id_completion(ctx, param, incomplete):
 
 
 @click.group(invoke_without_command=True, help="Perform actions on an individual workspace")
-@click.argument('workspace_id', envvar='TRECLI_WORKSPACE_ID', required=True, shell_complete=workspace_id_completion)
+@click.argument('workspace_id', envvar='TRECLI_WORKSPACE_ID', type=click.UUID, required=True, shell_complete=workspace_id_completion)
 @click.pass_context
 def workspace(ctx: click.Context, workspace_id: str) -> None:
     ctx.obj = WorkspaceContext(workspace_id)

--- a/tre/commands/workspaces/workspace_services/workspace_service.py
+++ b/tre/commands/workspaces/workspace_services/workspace_service.py
@@ -7,7 +7,7 @@ from .contexts import WorkspaceWorkspaceServiceContext, pass_workspace_workspace
 
 
 @click.group(name="workspace-service", invoke_without_command=True, help="Perform actions on an workspace-service")
-@click.argument('service_id', required=True)
+@click.argument('service_id', required=True, type=click.UUID)
 @click.pass_context
 def workspace_workspace_service(ctx: click.Context, service_id) -> None:
     ctx.obj = WorkspaceWorkspaceServiceContext.add_service_id_to_context_obj(ctx, service_id)


### PR DESCRIPTION
This gives a more helpful error when you forget to pluralise a collection,
e.g. 'tre workspace list'
